### PR TITLE
Make wfv binary runnable without interactive mode

### DIFF
--- a/app/lib.go
+++ b/app/lib.go
@@ -1,12 +1,15 @@
 package app
 
-import "github.com/vpofe/which-fix-version/tui"
+import (
+	"github.com/vpofe/which-fix-version/git"
+	"github.com/vpofe/which-fix-version/tui"
+)
 
 type App struct {
 	Model tui.Model
 }
 
-func NewApp() (app App) {
-	app.Model = tui.InitialModel()
+func NewApp(gc *git.GitConfig) (app App) {
+	app.Model = tui.InitialModel(gc)
 	return
 }

--- a/cmd/which-fix-version/main.go
+++ b/cmd/which-fix-version/main.go
@@ -1,17 +1,96 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/vpofe/which-fix-version/app"
+	"github.com/vpofe/which-fix-version/git"
 )
 
-func main() {
-	app := app.NewApp()
+func NewFindCommand() *FindCommand {
+	fc := &FindCommand{
+		fs: flag.NewFlagSet("find", flag.ContinueOnError),
+	}
+
+	fc.fs.StringVar(&fc.commitHash, "commitHash", "", "the main/master/development/custom branch commit hash to find the minimal fix version")
+	fc.fs.StringVar(&fc.url, "url", "", "git repository url")
+	fc.fs.StringVar(&fc.remoteName, "remoteName", "origin", "remote name to fetch branches from")
+	fc.fs.StringVar(&fc.developmentBranchName, "developmentBranchName", "main", "name of the central development branch")
+	fc.fs.StringVar(&fc.releaseBranchPrependIdentifiers, "releaseBranchPrependIdentifiers", "release- releases/ release/", "all string characters before the release version")
+
+	return fc
+}
+
+type FindCommand struct {
+	fs *flag.FlagSet
+
+	url                             string
+	remoteName                      string
+	developmentBranchName           string
+	releaseBranchPrependIdentifiers string
+	commitHash                      string
+}
+
+func (g *FindCommand) Name() string {
+	return g.fs.Name()
+}
+
+func (g *FindCommand) Init(args []string) error {
+	return g.fs.Parse(args)
+}
+
+func (g *FindCommand) Run() error {
+	app := app.NewApp(&git.GitConfig{
+		CommitHash:                      g.commitHash,
+		URL:                             g.url,
+		RemoteName:                      g.remoteName,
+		DevelopBranchName:               g.developmentBranchName,
+		ReleaseBranchPrependIdentifiers: strings.Split(g.releaseBranchPrependIdentifiers, " "),
+	})
+
 	if err := tea.NewProgram(app.Model).Start(); err != nil {
 		fmt.Printf("could not start program: %s\n", err)
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+type Runner interface {
+	Init([]string) error
+	Run() error
+	Name() string
+}
+
+func root(args []string) error {
+	if len(args) < 1 {
+		return errors.New("please choose your subcommand, available subcommands: find")
+	}
+
+	cmds := []Runner{
+		NewFindCommand(),
+	}
+
+	subcommand := os.Args[1]
+
+	for _, cmd := range cmds {
+		if cmd.Name() == subcommand {
+			cmd.Init(os.Args[2:])
+			return cmd.Run()
+		}
+	}
+
+	return fmt.Errorf("unknown subcommand: %s, available subcommands: find", subcommand)
+}
+
+func main() {
+	if err := root(os.Args[1:]); err != nil {
+		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
* support of CLI flags
* implement subcommand structure and implemented `wfv find`
* git functions work with gitOptions struct that also guides the inputs
* if all flags are provided, interactive inputs are skipped by default
* removing all hardcoded logic from tui

Left to do:
* Better CLI logging
* Loads of fixmes